### PR TITLE
Make Linux version work

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,19 +1,10 @@
 load(":qt_helper.bzl", "create_platfroms_folder")
+load(":qt_libraries.bzl", "QT_LIBRARIES")
 
 # Works only on Windows
 create_platfroms_folder()
 
 ### The following sections is copied and from https://github.com/justbuchanan/bazel_rules_qt/blob/master/qt.BUILD
-QT_LIBRARIES = [
-    ("core", "QtCore", "Qt6Core", []),
-    ("network", "QtNetwork", "Qt6Network", []),
-    ("widgets", "QtWidgets", "Qt6Widgets", [":qt_core", ":qt_gui"]),
-    ("quick", "QtQuick", "Qt6Quick", [":qt_gui", ":qt_qml"]),
-    ("qml", "QtQml", "Qt6Qml", [":qt_core", ":qt_network"]),
-    ("qml_models", "QtQmlModels", "Qt6QmlModels", []),
-    ("gui", "QtGui", "Qt6Gui", [":qt_core"]),
-    ("opengl", "QtOpenGL", "Qt6OpenGL", []),
-]
 
 [
     cc_library(
@@ -28,7 +19,7 @@ QT_LIBRARIES = [
 ]
 
 ### end of copied code from https://github.com/justbuchanan/bazel_rules_qt/blob/master/qt.BUILD
-### The copied code 
+### The copied code
 
 cc_binary(
     name = "Qt6HelloWorld",
@@ -38,7 +29,16 @@ cc_binary(
         ":qt_qml",
         ":qt_widgets",
     ],
-    #data = [
-    #   "@qt//:platform_files",
-    #]
+    env = select({
+        "@platforms//os:linux": {
+            "QT_QPA_PLATFORM_PLUGIN_PATH": "external/qt_6.1.0_linux_desktop_gcc_64/plugins",
+        },
+        "@platforms//os:windows": {
+            # TODO
+        },
+    }),
+    data = select({
+        "@platforms//os:linux": ["@qt_6.1.0_linux_desktop_gcc_64//:plugin_files"],
+        "@platforms//os:windows": [],
+    }),
 )

--- a/qt_6.1.0_linux_desktop_gcc_64.BUILD
+++ b/qt_6.1.0_linux_desktop_gcc_64.BUILD
@@ -1,55 +1,21 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
-
-QT_LIBRARIES = [
-    ("core", "QtCore", "Qt6Core", []),
-    ("network", "QtNetwork", "Qt6Network", []),
-    ("widgets", "QtWidgets", "Qt6Widgets", [":qt_core", ":qt_gui"]),
-    ("quick", "QtQuick", "Qt6Quick", [":qt_gui", ":qt_qml"]),
-    ("qml", "QtQml", "Qt6Qml", [":qt_core", ":qt_network"]),
-    ("qml_models", "QtQmlModels", "Qt6QmlModels", []),
-    ("gui", "QtGui", "Qt6Gui", [":qt_core"]),
-    ("opengl", "QtOpenGL", "Qt6OpenGL", []),
-]
-
-[
-    cc_import(
-        name = "qt_%s_linux_import" % name,
-        # When being on Linux this glob will be empty
-        hdrs = glob(["include/%s/**" % include_folder], allow_empty = True),
-        interface_library = "lib/lib%s.so" % library_name,
-        shared_library = "lib/lib%s.so" % library_name,
-        # Not available in cc_import (See: https://github.com/bazelbuild/bazel/issues/12745)
-        #target_compatible_with = ["@platforms//os:linux"],
-    )
-    for name, include_folder, library_name, _ in QT_LIBRARIES
-]
+load("@//:qt_libraries.bzl", "QT_LIBRARIES")
 
 [
     cc_library(
         name = "qt_%s_linux" % name,
-        # When being on Linux this glob will be empty
-        hdrs = glob(["include/%s/**" % include_folder], allow_empty = True),
+        hdrs = glob(["include/%s/**" % include_folder]),
+        srcs = glob([
+            "lib/lib%s.so*" % library_name,
+            "lib/libicu*.so*",
+        ]),
         includes = ["include"],
         # Available from Bazel 4.0.0
         target_compatible_with = ["@platforms//os:linux"],
-        deps = [":qt_%s_linux_import" % name],
         visibility = ["//visibility:public"],
     )
-    for name, include_folder, _, _ in QT_LIBRARIES
+    for name, include_folder, library_name, _ in QT_LIBRARIES
 ]
-
-#[
-#    cc_library(
-#        name = "qt_%s_linux" % name,
-#        # When being on Windows this glob will be empty
-#        hdrs = glob(["include/%s/**" % include_folder], allow_empty = True),
-#        includes = ["include"],
-#        linkopts = ["-l%s" % library_name],
-#        target_compatible_with = ["@platforms//os:linux"],
-#        visibility = ["//visibility:public"],
-#    )
-#    for name, include_folder, library_name, _ in QT_LIBRARIES
-#]
 
 filegroup(
     name = "uic",
@@ -60,5 +26,11 @@ filegroup(
 filegroup(
     name = "moc",
     srcs = ["libexec/moc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "plugin_files",
+    srcs = glob(["plugins/**/*"]),
     visibility = ["//visibility:public"],
 )

--- a/qt_libraries.bzl
+++ b/qt_libraries.bzl
@@ -1,0 +1,11 @@
+QT_LIBRARIES = [
+    ("core", "QtCore", "Qt6Core", []),
+    ("network", "QtNetwork", "Qt6Network", []),
+    ("widgets", "QtWidgets", "Qt6Widgets", [":qt_core", ":qt_gui"]),
+    ("quick", "QtQuick", "Qt6Quick", [":qt_gui", ":qt_qml"]),
+    ("qml", "QtQml", "Qt6Qml", [":qt_core", ":qt_network"]),
+    ("qml_models", "QtQmlModels", "Qt6QmlModels", []),
+    ("gui", "QtGui", "Qt6Gui", [":qt_core", ":qt_dbus"]),
+    ("opengl", "QtOpenGL", "Qt6OpenGL", [":qt_dbus"]),
+    ("dbus", "QtDBus", "Qt6DBus", []),
+]


### PR DESCRIPTION
This PR makes the Linux version of the example work by proving all
`libQt*.so*` files (not only the ones ending in `.so`, but also
`.so.6`). Before, it didn't work as the libraries' `SONAME`s are
`*.so.6` and the Bazel rules only provided the `*.so` symlinks.

We also make `libicu*.so*` available, since all `libQt*.so*` libraries
depend on that.

Lastly, we put Qt's `plugin` directory into a `filegroup`, make that
available via the `data` argument, and set the
`QT_QPA_PLATFORM_PLUGIN_PATH` environment variable so that Qt finds it
at runtime.

See also the [answer](https://stackoverflow.com/questions/67671236/bazel-rules-for-qt6-on-linux-how-to-copy-required-libs/71748925#71748925) on SO for more details.