### PR TITLE
Allow headers include with <>

### DIFF
--- a/qt_linux_x86_64.BUILD
+++ b/qt_linux_x86_64.BUILD
@@ -8,7 +8,10 @@ load("@rules_qt//:qt_libraries.bzl", "QT_LIBRARIES")
             "lib/libicu*.so*",
         ]),
         hdrs = glob(["include/%s/**" % include_folder]),
-        includes = ["include"],
+        includes = [
+            "include",
+            "include/%s" % include_folder,
+        ],
         target_compatible_with = ["@platforms//os:linux"],
         visibility = ["//visibility:public"],
     )

--- a/qt_mac_aarch64.BUILD
+++ b/qt_mac_aarch64.BUILD
@@ -6,7 +6,7 @@ load("@rules_qt//:qt_libraries.bzl", "QT_LIBRARIES")
         hdrs = glob(["include/%s/**" % include_folder]),  # allow_empty = True
         includes = [
             "include",
-            "include/QtCore",
+            "include/%s" % include_folder,
         ],
         linkopts = ["-F/opt/homebrew/lib"] + [
             "-framework %s" % library_name.replace("6", ""),  # macOS qt libs do not contain a 6 - e.g. instead of Qt6Core the lib is called QtCore

--- a/qt_mac_x86_64.BUILD
+++ b/qt_mac_x86_64.BUILD
@@ -6,7 +6,7 @@ load("@rules_qt//:qt_libraries.bzl", "QT_LIBRARIES")
         hdrs = glob(["include/%s/**" % include_folder]),  # allow_empty = True
         includes = [
             "include",
-            "include/QtCore",
+            "include/%s" % include_folder,
         ],
         linkopts = ["-F/usr/local/opt/qt@6/lib"] + [
             "-framework %s" % library_name.replace("6", ""),  # macOS qt libs do not contain a 6 - e.g. instead of Qt6Core the lib is called QtCore

--- a/qt_windows_x86_64.BUILD
+++ b/qt_windows_x86_64.BUILD
@@ -23,7 +23,10 @@ load("@rules_qt//:qt_libraries.bzl", "QT_LIBRARIES")
             ["include/%s/**" % include_folder],
             allow_empty = True,
         ),
-        includes = ["include"],
+        includes = [
+            "include",
+            "include/%s" % include_folder,
+        ],
         target_compatible_with = ["@platforms//os:windows"],
         visibility = ["//visibility:public"],
         deps = [":qt_%s_windows_import" % name],

--- a/tests/hello_world/hello_world.cpp
+++ b/tests/hello_world/hello_world.cpp
@@ -1,7 +1,7 @@
-#include <QtCore/QThread>
+#include <QThread>
 #include <QtCore/QVariant>
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QLabel>
+#include <QLabel>
 #include <QtWidgets/QStylePainter>
 
 class MyWidget : public QWidget


### PR DESCRIPTION
Apply the patch suggested by ankit-agarwal1999, which allows linux builds to use both official ways to include Qt headers.

https://github.com/Vertexwahn/rules_qt6/issues/12#issuecomment-1423059773